### PR TITLE
main: updating the version properly pin patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Used to create the Internal Load Balancer for DC/OS on GCP
 ```hcl
 module "dcos-backend-service" {
   source  = "dcos-terraform/backend-service/gcp"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   dcos_role = "master"
   project_id = "myid"

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  * ```hcl
  * module "dcos-backend-service" {
  *   source  = "dcos-terraform/backend-service/gcp"
- *   version = "~> 0.1"
+ *   version = "~> 0.1.0"
  *
  *   dcos_role = "master"
  *   project_id = "myid"


### PR DESCRIPTION
This updates the version behaivor to have ~> 0.1.0: any non-beta version >= 0.1.0 and < 0.2.0

https://www.terraform.io/docs/modules/usage.html#gt-1-2